### PR TITLE
fix: missing constraint components

### DIFF
--- a/tests/shapels_test.py
+++ b/tests/shapels_test.py
@@ -54,8 +54,10 @@ EX = Namespace('http://ex.tt/')
                                 SANode(Op.HASVALUE, [EX['class1']])], SH.ClassConstraintComponent),
          SANode(Op.TEST, [SH.DatatypeConstraintComponent, XSD.string], SH.DatatypeConstraintComponent),
          SANode(Op.TEST, [SH.NodeKindConstraintComponent, SH.IRI], SH.NodeKindConstraintComponent),
-         SANode(Op.TEST, ['numeric_range', SH.MinExclusiveConstraintComponent, Literal(1), SH.MaxInclusiveConstraintComponent, Literal(10)]),
-         SANode(Op.TEST, ['length_range', SH.MinLengthConstraintComponent, Literal(1), SH.MaxLengthConstraintComponent, Literal(10)]),
+         SANode(Op.TEST, ['numeric_range', SH.MinExclusiveConstraintComponent, Literal(1), SH.MaxInclusiveConstraintComponent, Literal(10)],
+                (SH.MinExclusiveConstraintComponent, SH.MaxInclusiveConstraintComponent)),
+         SANode(Op.TEST, ['length_range', SH.MinLengthConstraintComponent, Literal(1), SH.MaxLengthConstraintComponent, Literal(10)],
+                (SH.MinLengthConstraintComponent, SH.MaxLengthConstraintComponent)),
          SANode(Op.TEST, [SH.PatternConstraintComponent, '^B', [Literal('i')]], SH.PatternConstraintComponent)])}),
     ('shape_value_in_closed.ttl',
      {EX.shape: SANode(Op.AND, [
@@ -66,60 +68,66 @@ EX = Namespace('http://ex.tt/')
              SANode(Op.HASVALUE, [EX.val2]),
              SANode(Op.HASVALUE, [EX.val3]),
              SANode(Op.HASVALUE, [EX.val4])], SH.InConstraintComponent),
-         SANode(Op.CLOSED, [PANode(POp.PROP, [EX.p1]), PANode(POp.PROP, [EX.p2]), PANode(POp.PROP, [EX.p3])])], SH.ClosedConstraintComponent),
+         SANode(Op.CLOSED, [PANode(POp.PROP, [EX.p1]), PANode(POp.PROP, [EX.p2]), PANode(POp.PROP, [EX.p3])], SH.ClosedConstraintComponent)]),
       EX.pshape1: SANode(Op.COUNTRANGE, [Literal(1), None, PANode(POp.PROP, [EX.p3]),
-                                         SANode(Op.HASVALUE, [EX.val5])], SH.HasValueConstraintComponent),
+                                         SANode(Op.HASVALUE, [EX.val5], SH.HasValueConstraintComponent)]),
       EX.pshape2: SANode(Op.COUNTRANGE, [Literal(1), 
                                          None,
                                          PANode(POp.COMP, [
                                             PANode(POp.PROP, [EX.p4]),
                                             PANode(POp.PROP, [EX.p5])
                                          ]),
-                                         SANode(Op.HASVALUE, [EX.val6])], SH.HasValueConstraintComponent)}),
+                                         SANode(Op.HASVALUE, [EX.val6], SH.HasValueConstraintComponent)])}),
     ('shape_card_qual.ttl',
      {EX.shape1: SANode(Op.COUNTRANGE, [Literal(3), Literal(6),
                                         PANode(POp.PROP, [EX.p1]),
-                                        SANode(Op.TOP, [])]),
+                                        SANode(Op.TOP, [])],
+                        (SH.MinCountConstraintComponent, SH.MaxCountConstraintComponent)),
       EX.shape: SANode(Op.AND, [
-          SANode(Op.HASSHAPE, [EX.shape2]),
-          SANode(Op.HASSHAPE, [EX.shape3])]),
+          SANode(Op.HASSHAPE, [EX.shape2], SH.PropertyConstraintComponent),
+          SANode(Op.HASSHAPE, [EX.shape3], SH.PropertyConstraintComponent)]),
       EX.shape2: SANode(Op.COUNTRANGE, [Literal(4), Literal(8),
                                 PANode(POp.PROP, [EX.p2]),
-                                SANode(Op.HASSHAPE, [EX.shape4])]),
+                                SANode(Op.HASSHAPE, [EX.shape4])],
+                        (
+                            SH.QualifiedMinCountConstraintComponent,
+                            SH.QualifiedMaxCountConstraintComponent
+                        )),
       EX.shape3: SANode(Op.COUNTRANGE, [Literal(7), None,
                                         PANode(POp.PROP, [EX.p3]),
                                         SANode(Op.AND, [
                                             SANode(Op.HASSHAPE, [EX.shape5]),
                                             SANode(Op.NOT, [
                                                 SANode(Op.HASSHAPE,
-                                                        [EX.shape4])])])])}),
+                                                        [EX.shape4])])])],
+                            SH.QualifiedMinCountConstraintComponent)}),
     ('shape_pair.ttl',
      {EX.shape: SANode(Op.AND, [
         SANode(Op.EQ, [PANode(POp.PROP, [EX.p1]),
-                       PANode(POp.PROP, [EX.p2])]),
+                       PANode(POp.PROP, [EX.p2])], SH.EqualsConstraintComponent),
         SANode(Op.DISJ, [PANode(POp.PROP, [EX.p1]),
-                         PANode(POp.PROP, [EX.p3])]),
+                         PANode(POp.PROP, [EX.p3])], SH.DisjointConstraintComponent),
         SANode(Op.LESSTHAN, [PANode(POp.PROP, [EX.p1]),
-                             PANode(POp.PROP, [EX.p4])]),
+                             PANode(POp.PROP, [EX.p4])], SH.LessThanConstraintComponent),
         SANode(Op.LESSTHANEQ, [PANode(POp.PROP, [EX.p1]),
-                               PANode(POp.PROP, [EX.p5])])])}),
+                               PANode(POp.PROP, [EX.p5])], SH.LessThanOrEqualsConstraintComponent)])}),
     ('shape_all.ttl',
      {EX.shape: SANode(Op.AND, [
          SANode(Op.FORALL, [
              PANode(POp.PROP, [EX.p1]),
-             SANode(Op.TEST, [SH.NodeKindConstraintComponent, SH.Literal])]),
+             SANode(Op.TEST, [SH.NodeKindConstraintComponent, SH.Literal], SH.NodeKindConstraintComponent)]),
          SANode(Op.COUNTRANGE, [Literal(1), 
                                 None,
                                 PANode(POp.PROP, [EX.p1]),
-                                SANode(Op.HASVALUE, [Literal(10)])])])}),
+                                SANode(Op.HASVALUE, [Literal(10)], SH.HasValueConstraintComponent)])])}),
     ('shape_lang.ttl',
      {EX.shape: SANode(Op.AND, [
         SANode(Op.FORALL, [PANode(POp.PROP, [EX.p1]),
-                           SANode(Op.TEST, [SH.LanguageInConstraintComponent, [Literal('en'), Literal('nl')]])]),
-        SANode(Op.UNIQUELANG, [PANode(POp.PROP, [EX.p1])])])}),
+                           SANode(Op.TEST, [SH.LanguageInConstraintComponent, [Literal('en'), Literal('nl')]], SH.LanguageInConstraintComponent)]),
+        SANode(Op.UNIQUELANG, [PANode(POp.PROP, [EX.p1])], SH.UniqueLangConstraintComponent)])}),
     ('shape_ideqdisj.ttl',
-     {EX.shape1: SANode(Op.EQ, [PANode(POp.ID, []), PANode(POp.PROP, [EX.p])]),
-      EX.shape2: SANode(Op.DISJ, [PANode(POp.ID, []), PANode(POp.PROP, [EX.p])])})])
+     {EX.shape1: SANode(Op.EQ, [PANode(POp.ID, []), PANode(POp.PROP, [EX.p])], SH.EqualsConstraintComponent),
+      EX.shape2: SANode(Op.DISJ, [PANode(POp.ID, []), PANode(POp.PROP, [EX.p])], SH.DisjointConstraintComponent)})])
 def test_shape_parsing(graph_file, expected):
     print('==========================')
     print('==========================')


### PR DESCRIPTION
I missed some constraint components in the original merge request, and the tests were passing misleadingly since I forget to add comparing constraint components in the `__eq__` function.
This also makes it so a node can have multiple constraint components. This is needed for the constraint components for minCount and maxCount and also for qualifiedValueShape constraint components. The MinLengthConstraintComponent, MaxLengthConstraintComponent and the Min/MaxExclusive/InclusiveConstraintComponents are now also inside the constraint component attribute for consistency.